### PR TITLE
[github/actions/dependabot] fix dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,8 +32,8 @@ updates:
       - "Composer"
       - "Dependencies"
     commit-message:
-      prefix: "[composer/update]"
-      prefix-development: "[composer/dev/update]"
+      prefix: "[composer]"
+      prefix-development: "[composer/dev]"
       include: "scope"
     pull-request-branch-name:
       separator: "/"


### PR DESCRIPTION
```
The property '#/updates/1/commit-message/prefix' was not of a maximum string length of 15
The property '#/updates/1/commit-message/prefix-development' was not of a maximum string length of 15
```